### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/dist/browser/QuillDeltaToHtmlConverter.bundle.js
+++ b/dist/browser/QuillDeltaToHtmlConverter.bundle.js
@@ -1129,7 +1129,7 @@ function encodeMapping(str, mapping) {
     return str.replace(new RegExp(mapping[0], 'g'), mapping[1]);
 }
 function decodeMapping(str, mapping) {
-    return str.replace(new RegExp(mapping[1], 'g'), mapping[0].replace('\\', ''));
+    return str.replace(new RegExp(mapping[1], 'g'), mapping[0].replace(/\\/g, ''));
 }
 
 },{}],10:[function(require,module,exports){


### PR DESCRIPTION
Potential fix for [https://github.com/MartinRiese/quill-delta-to-html/security/code-scanning/3](https://github.com/MartinRiese/quill-delta-to-html/security/code-scanning/3)

To fix the problem, we need to ensure that all occurrences of the backslash character are replaced. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we should replace `mapping[0].replace('\\', '')` with `mapping[0].replace(/\\/g, '')` to ensure that all backslashes are removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
