### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/funcs-html.ts
+++ b/src/funcs-html.ts
@@ -78,7 +78,7 @@ function encodeMapping(str: string, mapping: string[]) {
   return str.replace(new RegExp(mapping[0], 'g'), mapping[1]);
 }
 function decodeMapping(str: string, mapping: string[]) {
-  return str.replace(new RegExp(mapping[1], 'g'), mapping[0].replace('\\', ''));
+  return str.replace(new RegExp(mapping[1], 'g'), mapping[0].replace(/\\/g, ''));
 }
 export {
   makeStartTag,


### PR DESCRIPTION
Potential fix for [https://github.com/MartinRiese/quill-delta-to-html/security/code-scanning/2](https://github.com/MartinRiese/quill-delta-to-html/security/code-scanning/2)

To fix the problem, we need to ensure that all occurrences of the backslash character are replaced in the `decodeMapping` function. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we should replace the `replace` method call on line 81 with a version that uses a regular expression to match all occurrences of the backslash character.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
